### PR TITLE
Omits extension methods module from documentation

### DIFF
--- a/src/source/Yaaf.Database/AbstractApplicationDbContext.fs
+++ b/src/source/Yaaf.Database/AbstractApplicationDbContext.fs
@@ -39,6 +39,7 @@ type IUpgradeDatabaseProvider =
     abstract GetMigrator : unit -> DbMigrator
     abstract FixScript : string -> string
 
+/// [omit]
 [<System.Runtime.CompilerServices.Extension>]
 module DatabaseUpgrade =
   let internal notImpl () =


### PR DESCRIPTION
If you add `[omit]` to the extension methods' modules FSharp.Formating will not try to generate documentation for them and it will not fail.
In this way you won't have to disable and enable extension methods in order to generate docs.
